### PR TITLE
fix: preserve Proton's S: gamedrive mapping when launching TeamSpeak

### DIFF
--- a/Arma3Helper.sh
+++ b/Arma3Helper.sh
@@ -111,6 +111,26 @@ fi
 
 export STEAM_COMPAT_DATA_PATH="$COMPAT_DATA_PATH"
 export STEAM_COMPAT_CLIENT_INSTALL_PATH="$HOME/.steam/steam"
+# Proton builds with the gamedrive option enabled (e.g. Proton Hotfix) need these
+# two variables to resolve the game's Steam library during `proton run`. When they
+# are missing, Proton DELETES the S: drive mapping from the live prefix, and a
+# running Arma then fails server signature checks on every S:-pathed file
+# (random "not signed by a key accepted" / "Wrong signature for file" kicks
+# while TeamSpeak is open). The compatdata folder always lives in the same
+# Steam library as the game, so derive both from COMPAT_DATA_PATH — but only
+# export them when the derived library actually contains the game, so a
+# noncanonical COMPAT_DATA_PATH can never point Proton at a wrong library.
+if [[ -z "$STEAM_COMPAT_INSTALL_PATH" && -z "$STEAM_COMPAT_LIBRARY_PATHS" ]]; then
+	_ARMA_LIBRARY="$(readlink -f "$COMPAT_DATA_PATH" 2>/dev/null)"
+	_ARMA_LIBRARY="${_ARMA_LIBRARY%/compatdata/*}"
+	if [[ -d "$_ARMA_LIBRARY/common/Arma 3" ]]; then
+		export STEAM_COMPAT_INSTALL_PATH="$_ARMA_LIBRARY/common/Arma 3"
+		export STEAM_COMPAT_LIBRARY_PATHS="$_ARMA_LIBRARY"
+	else
+		echo -e "\e[33mWarning\e[0m: Could not locate Arma's Steam library from COMPAT_DATA_PATH."
+		echo "Without STEAM_COMPAT_INSTALL_PATH and STEAM_COMPAT_LIBRARY_PATHS, newer Proton versions remove the prefix's S: drive, which breaks server signature checks. Export both in your config file."
+	fi
+fi
 export SteamAppId="107410"
 export SteamGameId="107410"
 if [[ "$ESYNC" == "false" ]]; then


### PR DESCRIPTION
## Problem

Launching TeamSpeak through `Arma3Helper.sh` deletes the `S:` drive mapping from the Arma prefix on Proton builds that enable the `gamedrive` option (current **Proton Hotfix** does by default).

The script exports `STEAM_COMPAT_DATA_PATH` but not `STEAM_COMPAT_INSTALL_PATH` / `STEAM_COMPAT_LIBRARY_PATHS`, and then invokes the full `proton run` verb. Proton's gamedrive setup needs both variables to resolve the game's Steam library (see `try_get_game_library_dir()` — [proton, proton_11.0 branch](https://github.com/ValveSoftware/Proton/blob/proton_11.0/proton), the check is at ~line 275 in the shipped Proton Hotfix script). When either is missing it returns `None` and `setup_dir_drive()` **removes `pfx/dosdevices/s:`** from the live prefix.

### Symptom this causes

Arma keeps running on already-open file handles, but multiplayer signature verification (`verifySignatures = 2` servers) re-opens PBOs on demand. Every file Arma loads through `S:` then fails the check, producing kicks like:

```
Files "dta\bin.pbo" are not signed by a key accepted by this server.
Player X: Wrong signature for file S:\workshop\content\107410\<id>\addons\<name>.pbo
```

naming a *different, provably-clean file each join* — but **only while TeamSpeak is running**. This is extremely confusing to debug from the game side (files validate, keys match, network is clean). Forensics that pinned it: the prefix's `dosdevices/` mtime matches the helper launch to the second, and across many kicks every flagged file was `S:`-pathed while `Z:`-pathed workshop mods never appeared once.

## Fix

Derive both variables from `COMPAT_DATA_PATH`, which always lives in the same Steam library as the game:

- runs only when the user hasn't already exported either variable (the config file is sourced earlier and can still override),
- canonicalizes with `readlink -f` first, and only exports when the derived `<library>/common/Arma 3` directory actually exists — a noncanonical/symlinked `COMPAT_DATA_PATH` can never point Proton at a wrong library,
- otherwise prints a warning telling the user to set both variables in their config, and changes nothing.

## Verified

Reproduced and fixed on Arch, Arma 3 2.20 + Proton Hotfix (Wine 11), TS3 + ACRE2 in the shared prefix: with the exports, `s:` survives the TeamSpeak launch (watched `dosdevices/` live), the ACRE game pipe still connects, and joins to a `verifySignatures=2` server pass cleanly with TS connected. `shellcheck` clean (zero findings before and after), `bash -n` passes, both derivation branches exercised (default-library path and custom-library path derive correctly; bogus path falls through to the warning).